### PR TITLE
Update libbpf submodule to v1.0 (properly this time)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,7 @@ LDFLAGS ?= -L$(LIBBPF_DIR)
 
 COMMON_USER_OBJ := common_user.o
 
-LIBS = -lbpf -lelf
+LIBS = -l:libbpf.a -lelf -lz
 
 all: llvm-check $(TARGET) $(XDP_OBJ) $(CMDLINE_TOOLS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,6 +81,7 @@ $(CMDLINE_TOOLS): %: %.c $(OBJECT_LIBBPF) Makefile $(COMMON_USER_OBJ)
 
 $(XDP_OBJ): %.o: %.c  common_kern_user.h
 	$(CLANG) -S \
+	    -target bpf \
 	    -D __BPF_TRACING__ \
 	    $(CFLAGS) \
 	    -Wall \
@@ -88,5 +89,5 @@ $(XDP_OBJ): %.o: %.c  common_kern_user.h
 	    -Wno-pointer-sign \
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
-	    -O2 -emit-llvm -c -g $<
+	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
 	$(LLC) -march=bpf -filetype=obj -o $@ ${@:.o=.ll}

--- a/src/Makefile
+++ b/src/Makefile
@@ -79,7 +79,7 @@ $(CMDLINE_TOOLS): %: %.c $(OBJECT_LIBBPF) Makefile $(COMMON_USER_OBJ)
 	$(CC) -Wall $(CFLAGS) $(LDFLAGS) -o $@ $(COMMON_USER_OBJ) \
 	 $< $(LIBS)
 
-$(XDP_OBJ): %.o: %.c  common_kern_user.h
+$(XDP_OBJ): %.o: %.c  common_kern_user.h shared_maps.h
 	$(CLANG) -S \
 	    -target bpf \
 	    -D __BPF_TRACING__ \

--- a/src/common_user.c
+++ b/src/common_user.c
@@ -21,9 +21,6 @@
 
 int verbose = 1; /* extern in common_user.h */
 
-/* Basedir due to iproute2 use this path */
-#define BASEDIR_MAPS "/sys/fs/bpf/tc/globals"
-
 const char *mapfile_txq_config = BASEDIR_MAPS "/map_txq_config";
 const char *mapfile_ip_hash    = BASEDIR_MAPS "/map_ip_hash";
 const char *mapfile_ifindex_type = BASEDIR_MAPS "/map_ifindex_type";

--- a/src/common_user.h
+++ b/src/common_user.h
@@ -26,6 +26,9 @@ extern int verbose; /* common_user.c */
  * Map files shared between TC and XDP program, are due to iproute2
  * limitations, located under /sys/fs/bpf/tc/globals/
  */
+/* Basedir due to iproute2 use this path */
+#define BASEDIR_MAPS "/sys/fs/bpf/tc/globals"
+
 extern const char *mapfile_txq_config; /* located in common_user.c */
 extern const char *mapfile_ip_hash;
 extern const char *mapfile_ifindex_type;

--- a/src/shared_maps.h
+++ b/src/shared_maps.h
@@ -1,0 +1,26 @@
+#ifndef SHARED_MAPS_H
+#define SHARED_MAPS_H
+
+#include <bpf/bpf_helpers.h>
+
+#include "common_kern_user.h"
+
+/* Pinned shared map: see  mapfile_ip_hash */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, IP_HASH_ENTRIES_MAX);
+	__type(key, __u32);
+	__type(value, struct ip_hash_info);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} map_ip_hash SEC(".maps");
+
+/* Map shared with XDP programs */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_IFINDEX);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} map_ifindex_type SEC(".maps");
+
+#endif

--- a/src/tc_classify_kern.c
+++ b/src/tc_classify_kern.c
@@ -255,7 +255,7 @@ bool special_minor_classid(struct __sk_buff *skb,
  tc filter replace dev ixgbe2 prio 0xC000 handle 1 egress bpf da obj tc_classify_kern.o sec tc
  */
 SEC("tc")
-int  tc_cls_prog(struct __sk_buff *skb)
+int tc_iphash_to_cpu(struct __sk_buff *skb)
 {
 	__u32 cpu = bpf_get_smp_processor_id();
 	struct ip_hash_info *ip_info;

--- a/src/tc_classify_kern.c
+++ b/src/tc_classify_kern.c
@@ -19,7 +19,7 @@
 
  tc qdisc  del dev ixgbe2 clsact # clears all
  tc qdisc  add dev ixgbe2 clsact
- tc filter add dev ixgbe2 egress bpf da obj tc_classify_kern.o sec tc_classify
+ tc filter add dev ixgbe2 egress bpf da obj tc_classify_kern.o sec tc
  tc filter list dev ixgbe2 egress
 
 */
@@ -269,7 +269,7 @@ bool special_minor_classid(struct __sk_buff *skb,
 }
 
 /* Quick manual reload command:
- tc filter replace dev ixgbe2 prio 0xC000 handle 1 egress bpf da obj tc_classify_kern.o sec tc_classify
+ tc filter replace dev ixgbe2 prio 0xC000 handle 1 egress bpf da obj tc_classify_kern.o sec tc
  */
 SEC("tc")
 int  tc_cls_prog(struct __sk_buff *skb)

--- a/src/tc_classify_kern.c
+++ b/src/tc_classify_kern.c
@@ -271,7 +271,7 @@ bool special_minor_classid(struct __sk_buff *skb,
 /* Quick manual reload command:
  tc filter replace dev ixgbe2 prio 0xC000 handle 1 egress bpf da obj tc_classify_kern.o sec tc_classify
  */
-SEC("tc_classify")
+SEC("tc")
 int  tc_cls_prog(struct __sk_buff *skb)
 {
 	__u32 cpu = bpf_get_smp_processor_id();

--- a/src/tc_classify_user.c
+++ b/src/tc_classify_user.c
@@ -25,7 +25,7 @@ static const char *__doc__=
 static int map_txq_config_fd = -1;
 
 const char *bpf_obj  = "tc_classify_kern.o";
-const char *sec_name = "tc_classify";
+const char *sec_name = "tc";
 
 static const struct option long_options[] = {
 	{"help",	no_argument,		NULL, 'h' },

--- a/src/tc_classify_user.c
+++ b/src/tc_classify_user.c
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hq",
+	while ((opt = getopt_long(argc, argv, "hqblc:m:j:d:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'q':

--- a/src/tc_queue_mapping_kern.c
+++ b/src/tc_queue_mapping_kern.c
@@ -31,10 +31,7 @@
 #define TC_H_MAJOR(x) TC_H_MAJ(x)
 #define TC_H_MINOR(x) TC_H_MIN(x)
 
-/* Quick replace/reload command:
- *  tc filter replace dev ixgbe2 egress prio 0xC000 handle 1 bpf da obj tc_queue_mapping_kern.o sec tc_qmap2cpu
- */
-SEC("tc_qmap2cpu")
+SEC("tc")
 int  tc_cls_prog(struct __sk_buff *skb)
 {
 	__u32 cpu = bpf_get_smp_processor_id();
@@ -96,7 +93,7 @@ int  tc_cls_prog(struct __sk_buff *skb)
 
 #define barrier() __asm__ __volatile__("": : :"memory")
 
-SEC("tc_test_invalid_value")
+SEC("tc")
 int  tc_cls_prog_test(struct __sk_buff *skb)
 {
 	/* Kernel should not allow this to take effect */

--- a/src/xdp_iphash_to_cpu_cmdline.c
+++ b/src/xdp_iphash_to_cpu_cmdline.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
 	__u32 tc_handle = 0;
 	bool provided_classid = false;
 
-	while ((opt = getopt_long(argc, argv, "haxil:",
+	while ((opt = getopt_long(argc, argv, "hac:t:i:le",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'a':

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -30,14 +30,6 @@ struct bpf_map_def SEC("maps") map_ip_hash = {
 	.max_entries = IP_HASH_ENTRIES_MAX,
 };
 
-/* Pinned shared map: see  mapfile_txq_config */
-struct bpf_map_def SEC("maps") map_txq_config = {
-	.type        = BPF_MAP_TYPE_ARRAY,
-	.key_size    = sizeof(__u32),
-	.value_size  = sizeof(struct txq_config),
-	.max_entries = MAX_CPUS,
-};
-
 /* Pinned shared map: see  mapfile_ifindex_type */
 struct bpf_map_def SEC("maps") map_ifindex_type = {
 	.type        = BPF_MAP_TYPE_ARRAY,

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -197,7 +197,7 @@ __u32 handle_eth_protocol(struct xdp_md *ctx, __u16 eth_proto, __u32 l3_offset,
 }
 
 SEC("xdp")
-int  xdp_program(struct xdp_md *ctx)
+int xdp_iphash_to_cpu(struct xdp_md *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;
 	void *data     = (void *)(long)ctx->data;

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -218,7 +218,7 @@ __u32 handle_eth_protocol(struct xdp_md *ctx, __u16 eth_proto, __u32 l3_offset,
 	return XDP_PASS;
 }
 
-SEC("xdp_prog")
+SEC("xdp")
 int  xdp_program(struct xdp_md *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;
@@ -242,4 +242,3 @@ int  xdp_program(struct xdp_md *ctx)
 }
 
 char _license[] SEC("license") = "GPL";
-

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -10,10 +10,11 @@
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
-#include "bpf_helpers.h"
-#include "bpf_endian.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
 
 #include "common_kern_user.h"
+#include "shared_maps.h"
 
 #define DEBUG
 
@@ -22,36 +23,21 @@ struct vlan_hdr {
 	__be16 h_vlan_encapsulated_proto;
 };
 
-/* Pinned shared map: see  mapfile_ip_hash */
-struct bpf_map_def SEC("maps") map_ip_hash = {
-	.type        = BPF_MAP_TYPE_HASH,
-	.key_size    = sizeof(__u32),
-	.value_size  = sizeof(struct ip_hash_info),
-	.max_entries = IP_HASH_ENTRIES_MAX,
-};
-
-/* Pinned shared map: see  mapfile_ifindex_type */
-struct bpf_map_def SEC("maps") map_ifindex_type = {
-	.type        = BPF_MAP_TYPE_ARRAY,
-	.key_size    = sizeof(__u32),
-	.value_size  = sizeof(__u32),
-	.max_entries = MAX_IFINDEX,
-};
-
 /* Special map type that can XDP_REDIRECT frames to another CPU */
-struct bpf_map_def SEC("maps") cpu_map = {
-	.type		= BPF_MAP_TYPE_CPUMAP,
-	.key_size	= sizeof(__u32),
-	.value_size	= sizeof(__u32),
-	.max_entries	= MAX_CPUS,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_CPUMAP);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} cpu_map SEC(".maps");
 
-struct bpf_map_def SEC("maps") cpus_available = {
-        .type           = BPF_MAP_TYPE_ARRAY,
-        .key_size       = sizeof(__u32),
-        .value_size     = sizeof(__u32),
-        .max_entries    = MAX_CPUS,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, __u32);
+	__type(value, __u32);
+} cpus_available SEC(".maps");
 
 #ifdef  DEBUG
 /* Only use this for debug output. Notice output from bpf_trace_printk()

--- a/src/xdp_iphash_to_cpu_user.c
+++ b/src/xdp_iphash_to_cpu_user.c
@@ -451,7 +451,7 @@ int main(int argc, char **argv)
 	prog_load_attr_maps.file = filename;
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hSrqdwlc:q:",
+	while ((opt = getopt_long(argc, argv, "hSrqd:wlc:q:o:s:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'q':

--- a/src/xdp_iphash_to_cpu_user.c
+++ b/src/xdp_iphash_to_cpu_user.c
@@ -98,7 +98,6 @@ struct bpf_prog_load_attr_maps {
 /* below: shared pinned maps */
 static int ip_hash_map_fd = -1;
 static int ifindex_type_map_fd  = -1;
-static int txq_config_map_fd  = -1;
 
 /* below: private maps */
 static int cpu_map_fd = -1;
@@ -140,7 +139,6 @@ static int init_map_fds(struct bpf_object *obj,
 	cpus_available_map_fd= find_map_fd_by_name(obj,"cpus_available",attr);
 	ip_hash_map_fd       = find_map_fd_by_name(obj,"map_ip_hash", attr);
 	ifindex_type_map_fd  = find_map_fd_by_name(obj,"map_ifindex_type",attr);
-	txq_config_map_fd    = find_map_fd_by_name(obj,"map_txq_config", attr);
 
 	if (cpu_map_fd < 0 || ip_hash_map_fd < 0 ||
 	    cpus_available_map_fd < 0 || ifindex_type_map_fd < 0) {
@@ -402,16 +400,14 @@ int main(int argc, char **argv)
 	struct bpf_pinned_map my_pinned_maps[4];
 	struct bpf_prog_load_attr_maps prog_load_attr_maps = {
 		.prog_type	= BPF_PROG_TYPE_XDP,
-		.nr_pinned_maps	= 4,
+		.nr_pinned_maps	= 3,
 	};
 	my_pinned_maps[0].name     = "map_ip_hash";
 	my_pinned_maps[0].filename = mapfile_ip_hash;
 	my_pinned_maps[1].name     = "map_ifindex_type";
 	my_pinned_maps[1].filename = mapfile_ifindex_type;
-	my_pinned_maps[2].name     = "map_txq_config";
-	my_pinned_maps[2].filename = mapfile_txq_config;
-	my_pinned_maps[3].name     = "cpu_map";
-	my_pinned_maps[3].filename = mapfile_cpu_map;
+	my_pinned_maps[2].name     = "cpu_map";
+	my_pinned_maps[2].filename = mapfile_cpu_map;
 
 	prog_load_attr_maps.pinned_maps = my_pinned_maps;
 


### PR DESCRIPTION
This updates the libbpf submodule to 1.0, converting not just the userspace
code, but also map definitions and pinning logic. Hopefully this should be
enough to not break anything.

Since loading of the TC program is still done by shelling out to the 'tc'
binary, this will only work if 'tc' itself is compiled against libbpf and uses
that as its loader. The old 'tc' loader doesn't support BTF at all, so using it
will fail; this should be fairly obvious, though.

To avoid the dependency on the libbpf-enabled 'tc', the TC program loading can
be converted to the libbpf TC attachment code; however, I deemed that out of
scope for now, since things can work just fine this way.