### PR TITLE
Replace IP map with a Trie. Use 128-bit address storage, and store IP…

### DIFF
--- a/src/common_kern_user.h
+++ b/src/common_kern_user.h
@@ -4,6 +4,8 @@
 #ifndef __COMMON_KERN_USER_H
 #define __COMMON_KERN_USER_H
 
+#include <linux/in6.h>
+
 /* Interface (ifindex) direction type */
 #define INTERFACE_NONE	0	/* Not configured */
 #define INTERFACE_WAN	(1 << 0)
@@ -30,6 +32,12 @@ struct ip_hash_info {
 	/* lookup key: __u32 IPv4-address */
 	__u32 cpu;
 	__u32 tc_handle; /* TC handle MAJOR:MINOR combined in __u32 */
+};
+
+/* Key type used for map_ip_hash trie */
+struct ip_hash_key {
+	__u32 prefixlen; /* Length of the prefix to match */
+	struct in6_addr address; /* An IPv6 address. IPv4 uses the last 32 bits. */
 };
 
 #endif /* __COMMON_KERN_USER_H */

--- a/src/common_user.c
+++ b/src/common_user.c
@@ -8,6 +8,7 @@
 #include <sys/statfs.h>  /* statfs */
 #include <sys/stat.h>    /* stat(2) + S_IRWXU */
 #include <sys/mount.h>   /* mount(2) */
+#include <netdb.h>
 
 #include <linux/pkt_sched.h> /* TC_H_MAJ + TC_H_MIN */
 
@@ -75,11 +76,63 @@ bool map_txq_config_check_ip_info(int map_fd, struct ip_hash_info *ip_info) {
 	return true;
 }
 
+struct ip_hash_key ip_string_to_key(char *ip_string, __u32 prefix) {
+	struct ip_hash_key key;
+	int res;
+
+	key.address.__in6_u.__u6_addr32[0] = 0;
+        key.address.__in6_u.__u6_addr32[1] = 0;
+        key.address.__in6_u.__u6_addr32[2] = 0;
+	key.address.__in6_u.__u6_addr32[3] = 0;
+	key.prefixlen = 0;
+
+	struct addrinfo hints = {}, *result;
+	memset (&hints, 0, sizeof (hints));
+	hints.ai_family = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags |= AI_CANONNAME;
+	res = getaddrinfo(ip_string, NULL, &hints, &result);
+	if (res < 0) {
+		perror("getaddrinfo");
+		key.prefixlen = 0; /* Indicates fail */
+		return key;
+	}
+
+	switch (result->ai_family) {
+		case AF_INET:
+			key.address.__in6_u.__u6_addr32[3] = ((struct sockaddr_in *) result->ai_addr)->sin_addr.s_addr;
+			key.prefixlen = prefix + 96;
+			break;
+		case AF_INET6:
+			printf("IPv6\n");
+			key.address = ((struct sockaddr_in6 *) result->ai_addr)->sin6_addr;
+			key.prefixlen = prefix;
+			break;
+	}
+
+
+	freeaddrinfo(result);
+	return key;
+}
+
+void print_key_binary(struct ip_hash_key *key) {
+	if (key->address.__in6_u.__u6_addr32[0] == 0 && key->address.__in6_u.__u6_addr32[1] == 0 && key->address.__in6_u.__u6_addr32[2] == 0) {
+		/* It's IPv4 */
+		printf("IPv4: 0x%X/%d", key->address.__in6_u.__u6_addr32[3], key->prefixlen);
+	} else {
+		/* It's an IPv6 address */
+		printf("IPv6: 0x%X/0x%X/0x%X/0x%X/%d",  key->address.__in6_u.__u6_addr32[0],
+				 key->address.__in6_u.__u6_addr32[1],  key->address.__in6_u.__u6_addr32[2],
+				  key->address.__in6_u.__u6_addr32[3], key->prefixlen);
+	}
+}
+
 int iphash_modify(int fd, char *ip_string, unsigned int action,
-		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd)
+		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd,
+		  __u32 prefix)
 {
 	//printf ("In iphash_modify %u\n",cpu_idx);
-	__u32 key;
+	struct ip_hash_key key;
 	int res;
 	unsigned int nr_cpus = bpf_num_possible_cpus();
 	struct ip_hash_info ip_info;
@@ -91,18 +144,12 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 	ip_info.cpu       = cpu_idx;
 	ip_info.tc_handle = tc_handle;
 
-	/* Convert IP-string into 32-bit network byte-order value */
-	res = inet_pton(AF_INET, ip_string, &key);
-	if (res <= 0) {
-		if (res == 0)
-			fprintf(stderr,
-				"ERR: IPv4 \"%s\" not in presentation format\n",
-				ip_string);
-		else
-			perror("inet_pton");
+	/* Convert IP-string into network byte-order value */
+	key = ip_string_to_key(ip_string, prefix);
+	if (key.prefixlen == 0) {
 		return EXIT_FAIL_IP;
 	}
-	printf ("key: 0x%X\n", key);
+	print_key_binary(&key);
 	if (action == ACTION_ADD) {
 		//res = bpf_map_update_elem(fd, &key, &ip_info, BPF_NOEXIST);
 		if (!map_txq_config_check_ip_info(txq_map_fd, &ip_info))
@@ -118,8 +165,8 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 
 	if (res != 0) { /* 0 == success */
 		fprintf(stderr,
-			"%s() IP:%s key:0x%X errno(%d/%s)",
-			__func__, ip_string, key, errno, strerror(errno));
+			"%s() IP:%s errno(%d/%s)",
+			__func__, ip_string, errno, strerror(errno));
 
 		if (errno == 17) {
 			fprintf(stderr, ": Already in Iphash\n");
@@ -130,8 +177,8 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 	}
 	if (verbose)
 		fprintf(stderr,
-			"%s() IP:%s key:0x%X TC-handle:0x%X\n",
-			__func__, ip_string, key, tc_handle);
+			"%s() IP:%s TC-handle:0x%X\n",
+			__func__, ip_string, tc_handle);
 	return EXIT_OK;
 }
 

--- a/src/common_user.h
+++ b/src/common_user.h
@@ -43,7 +43,8 @@ extern const char *mapfile_cpu_map;
 #define ACTION_DEL	(1 << 1)
 
 int iphash_modify(int fd, char *ip_string, unsigned int action,
-		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd);
+		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd,
+		  __u32 prefix);
 
 bool locate_kern_object(char *execname, char *filename, size_t size);
 

--- a/src/shared_maps.h
+++ b/src/shared_maps.h
@@ -7,11 +7,12 @@
 
 /* Pinned shared map: see  mapfile_ip_hash */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__uint(max_entries, IP_HASH_ENTRIES_MAX);
-	__type(key, __u32);
+	__type(key, struct ip_hash_key);
 	__type(value, struct ip_hash_info);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_ip_hash SEC(".maps");
 
 /* Map shared with XDP programs */

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -7,6 +7,8 @@
 #include <linux/if_vlan.h>
 #include <linux/ip.h>
 #include <linux/in.h>
+#include <linux/ipv6.h>
+#include <linux/in6.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
 
@@ -102,55 +104,95 @@ bool parse_eth(struct ethhdr *eth, void *data_end,
 	return true;
 }
 
+static __always_inline struct ip_hash_info *get_ip_info(struct ip_hash_key *ip)
+{
+	struct ip_hash_info *ip_info;
+
+	ip_info = bpf_map_lookup_elem(&map_ip_hash, ip);
+	if (!ip_info) {
+		struct ip_hash_key null_addr;
+	        null_addr.prefixlen = 128;
+	        null_addr.address.in6_u.u6_addr32[0] = 0;
+	        null_addr.address.in6_u.u6_addr32[1] = 0;
+        	null_addr.address.in6_u.u6_addr32[2] = 0;
+	        null_addr.address.in6_u.u6_addr32[3] = 0;
+		/* On LAN side (XDP-ingress) some uncategorized traffic are
+		 * expected, e.g. services like DHCP are running and IPs
+		 * contacting captive portal (which are not yet configured)
+		 */
+		// bpf_debug("cant find ip_info->cpu id for ip:%u\n", ip);
+		// the all-zeroes address is for default traffic
+		ip_info = bpf_map_lookup_elem(&map_ip_hash, &null_addr);
+	}
+	return ip_info;
+}
+
 static __always_inline
-__u32 parse_ipv4(struct xdp_md *ctx, __u32 l3_offset, __u32 ifindex)
+__u32 parse_ip(struct xdp_md *ctx, __u32 l3_offset, __u32 ifindex, __u16 eth_proto)
 {
 	void *data_end = (void *)(long)ctx->data_end;
 	void *data     = (void *)(long)ctx->data;
+
+	/* aliases pointers used for v4/v6 based on version */
 	struct iphdr *iph = data + l3_offset;
+	struct ipv6hdr *ip6h = data + l3_offset;
 	__u32 *direction_lookup;
 	__u32 direction;
-	__u32 ip; /* type need to match map */
 	struct ip_hash_info *ip_info;
 	//u32 *cpu_id_lookup;
 	__u32 cpu_id;
 	__u32 *cpu_lookup;
 	__u32 cpu_dest;
 
-	/* Hint: +1 is sizeof(struct iphdr) */
-	if (iph + 1 > data_end) {
-		bpf_debug("Invalid IPv4 packet: L3off:%llu\n", l3_offset);
-		return XDP_PASS;
-	}
+	/* Setup the ip_hash_key lookup structure */
+	struct ip_hash_key lookup;
+        lookup.prefixlen = 128;
+        lookup.address.in6_u.u6_addr32[0] = 0;
+        lookup.address.in6_u.u6_addr32[1] = 0;
+        lookup.address.in6_u.u6_addr32[2] = 0;
+        lookup.address.in6_u.u6_addr32[3] = 0;
+
 	/* WAN or LAN interface? */
 	direction_lookup = bpf_map_lookup_elem(&map_ifindex_type, &ifindex);
 	if (!direction_lookup)
 		return XDP_PASS;
 	direction = *direction_lookup;
-	/* Extract key, XDP operate at "ingress" */
-	if (direction == INTERFACE_WAN) {
-		ip = iph->daddr;
-	} else if (direction == INTERFACE_LAN) {
-		ip = iph->saddr;
-	} else {
+	if (direction != INTERFACE_WAN && direction != INTERFACE_LAN) {
 		bpf_debug("Cant determin ifindex(%u) direction\n", ifindex);
 		return XDP_PASS;
 	}
 
-	ip_info = bpf_map_lookup_elem(&map_ip_hash, &ip);
-	if (!ip_info) {
-		/* On LAN side (XDP-ingress) some uncategorized traffic are
-		 * expected, e.g. services like DHCP are running and IPs
-		 * contacting captive portal (which are not yet configured)
-		 */
-		// bpf_debug("cant find ip_info->cpu id for ip:%u\n", ip);
-		// 255.255.255.255 is for default traffic
-		ip = bpf_ntohl(0xFFFFFFFF);
-		ip_info = bpf_map_lookup_elem(&map_ip_hash, &ip);
-		if (!ip_info) {
-			bpf_debug("cant find default cpu_idx_lookup\n");
+	/* we know it's v4 or v6, so just check the version field of the IP
+	 * header itself
+	 */
+	if (eth_proto == ETH_P_IP) { /* IPv4 */
+		/* Hint: +1 is sizeof(struct iphdr) */
+		if (iph + 1 > data_end) {
+			bpf_debug("Invalid IPv4 packet: L3off:%llu\n", l3_offset);
 			return XDP_PASS;
 		}
+
+		/* Extract key, XDP operate at "ingress" */
+		if (direction == INTERFACE_WAN) {
+			lookup.address.in6_u.u6_addr32[3] = iph->daddr;
+		} else if (direction == INTERFACE_LAN) {
+			lookup.address.in6_u.u6_addr32[3] = iph->saddr;
+		}
+	} else {
+		if (ip6h + 1 > data_end) {
+			bpf_debug("Invalid IPv4 packet: L3off:%llu\n", l3_offset);
+			return XDP_PASS;
+		}
+		if (direction == INTERFACE_WAN)
+			lookup.address = ip6h->daddr;
+		else if (direction == INTERFACE_LAN)
+			lookup.address = ip6h->saddr;
+	}
+
+	ip_info = get_ip_info(&lookup);
+	if (!ip_info) {
+		bpf_debug("cant find default cpu_idx_lookup\n");
+		return XDP_PASS;
 	}
 	cpu_id = ip_info->cpu;
 
@@ -181,11 +223,10 @@ __u32 handle_eth_protocol(struct xdp_md *ctx, __u16 eth_proto, __u32 l3_offset,
 
 	switch (eth_proto) {
 	case ETH_P_IP:
-		action = parse_ipv4(ctx, l3_offset, ifindex);
-		//bpf_debug("return from redirect %i\n",test);
+	case ETH_P_IPV6: 
+		action = parse_ip(ctx, l3_offset, ifindex, eth_proto);
 		return action;
 		break;
-	case ETH_P_IPV6: /* Not handler for IPv6 yet*/
 	case ETH_P_ARP:  /* Let OS handle ARP */
 		/* Fall-through */
 	default:


### PR DESCRIPTION
This PR does the following:

* Replaced the `map_ip_hash` structure with a `BPF_MAP_TYPE_LPM_TRIE`. The key is a new `ip_hash_key` structure, which contains a prefix length and 128-bit address storage.
* The `xdp_iphash_to_cpu_cmdline` has gained an extra flag, `--prefix`. You can add an address with a /24 using `xdp_iphash_to_cpu_cmdline --add --ip 100.64.1.3 --cpu 0 --classid 1:5 --prefix 24`.
* If you don't include `--prefix`, it defaults to `/32` for IPv4 and `/128` for IPv6 --- preserving compatibility with the existing setup (no changes required if you don't want to use these features).
* The command-line also now understands IPv6 addresses. So `xdp_iphash_to_cpu_cmdline --add --ip fe80::215:5dff:fe64:4d05 --cpu 0 --classid 1:5 --prefix 64` will setup a matcher for that IPv6 address and all of its children.
* The command-line `--list` function has changed to also show the prefix, e.g. `"100.64.1.3/24" : { "cpu" : 0, "tc_maj" : "1" , "tc_min" : "5" },` or `"fe80::215:5dff:fe64:4d05/64" : { "cpu" : 0, "tc_maj" : "1" , "tc_min" : "5" }`
* The `clear` command no-longer takes the really odd route of translating an address into a string, and then translating it right back again for each address to remove it; it just removes all items.
* Once read, all addresses are turned into 128-bit addresses. IPv4 is placed in the last 4 octets of the address, with the rest zeroed. The command-line adds 96 to IPv4 prefixes automatically, so you don't need to remember to turn /24 into /120 (which it will be internally).
* The classifier and `xdp_iphash_to_cpu` program use a Trie lookup, starting with 128-bits (trying for an exact match). In testing, it seems very fast. (I haven't formally benchmarked it)

My test environment consists of 3 VMs: one running the shaper (I'm using LibreQOS to generate the basic commands), and a VM on either side of a bridge in the shaper. `iperf` shows that it is shaping correctly both for known and unknown addresses, and is correctly placing prefixed addresses in the right group.

Also, if you add this you may want to reboot to get rid of the previous pinned map. I didn't add any code to remove/replace it.

FIXES https://github.com/xdp-project/xdp-cpumap-tc/issues/4

References: https://github.com/rchac/LibreQoS/issues/57
Tagging: @tohojo @interduo @rchac 
