### PR TITLE
Support IPv4 and IPv6 with prefix length, using a Trie

### DIFF
--- a/src/common_kern_user.h
+++ b/src/common_kern_user.h
@@ -4,6 +4,8 @@
 #ifndef __COMMON_KERN_USER_H
 #define __COMMON_KERN_USER_H
 
+#include <linux/in6.h>
+
 /* Interface (ifindex) direction type */
 #define INTERFACE_NONE	0	/* Not configured */
 #define INTERFACE_WAN	(1 << 0)
@@ -30,6 +32,12 @@ struct ip_hash_info {
 	/* lookup key: __u32 IPv4-address */
 	__u32 cpu;
 	__u32 tc_handle; /* TC handle MAJOR:MINOR combined in __u32 */
+};
+
+/* Key type used for map_ip_hash trie */
+struct ip_hash_key {
+	__u32 prefixlen; /* Length of the prefix to match */
+	struct in6_addr address; /* An IPv6 address. IPv4 uses the last 32 bits. */
 };
 
 #endif /* __COMMON_KERN_USER_H */

--- a/src/common_user.c
+++ b/src/common_user.c
@@ -107,7 +107,7 @@ struct ip_hash_key ip_string_to_key(char *ip_string) {
 	res = getaddrinfo(ip_string, NULL, &hints, &result);
 	if (res < 0) {
 		perror("getaddrinfo");
-		key.prefixlen = 0; /* Indicates fail */
+		key.prefixlen = 255; /* Indicates fail */
 		return key;
 	}
 
@@ -164,7 +164,7 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 
 	/* Convert IP-string into network byte-order value */
 	key = ip_string_to_key(ip_string);
-	if (key.prefixlen == 0) {
+	if (key.prefixlen == 255) {
 		return EXIT_FAIL_IP;
 	}
 	print_key_binary(&key);

--- a/src/common_user.c
+++ b/src/common_user.c
@@ -79,7 +79,7 @@ bool map_txq_config_check_ip_info(int map_fd, struct ip_hash_info *ip_info) {
 struct ip_hash_key ip_string_to_key(char *ip_string) {
 	struct ip_hash_key key;
 	int res;
-	char addr[42]; /* Temporary buffer if parsing IP */
+	char addr[INET6_ADDRSTRLEN]; /* Temporary buffer if parsing IP */
 
 	key.address.__in6_u.__u6_addr32[0] = 0;
         key.address.__in6_u.__u6_addr32[1] = 0;

--- a/src/common_user.c
+++ b/src/common_user.c
@@ -8,6 +8,7 @@
 #include <sys/statfs.h>  /* statfs */
 #include <sys/stat.h>    /* stat(2) + S_IRWXU */
 #include <sys/mount.h>   /* mount(2) */
+#include <netdb.h>
 
 #include <linux/pkt_sched.h> /* TC_H_MAJ + TC_H_MIN */
 
@@ -75,11 +76,63 @@ bool map_txq_config_check_ip_info(int map_fd, struct ip_hash_info *ip_info) {
 	return true;
 }
 
+struct ip_hash_key ip_string_to_key(char *ip_string, __u32 prefix) {
+	struct ip_hash_key key;
+	int res;
+
+	key.address.__in6_u.__u6_addr32[0] = 0;
+        key.address.__in6_u.__u6_addr32[1] = 0;
+        key.address.__in6_u.__u6_addr32[2] = 0;
+	key.address.__in6_u.__u6_addr32[3] = 0;
+	key.prefixlen = 0;
+
+	struct addrinfo hints = {}, *result;
+	memset (&hints, 0, sizeof (hints));
+	hints.ai_family = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags |= AI_CANONNAME;
+	res = getaddrinfo(ip_string, NULL, &hints, &result);
+	if (res < 0) {
+		perror("getaddrinfo");
+		key.prefixlen = 0; /* Indicates fail */
+		return key;
+	}
+
+	switch (result->ai_family) {
+		case AF_INET:
+			key.address.__in6_u.__u6_addr32[3] = ((struct sockaddr_in *) result->ai_addr)->sin_addr.s_addr;
+			key.prefixlen = prefix + 96;
+			break;
+		case AF_INET6:
+			printf("IPv6\n");
+			key.address = ((struct sockaddr_in6 *) result->ai_addr)->sin6_addr;
+			key.prefixlen = prefix;
+			break;
+	}
+
+
+	freeaddrinfo(result);
+	return key;
+}
+
+void print_key_binary(struct ip_hash_key *key) {
+	if (key->address.__in6_u.__u6_addr32[0] == 0 && key->address.__in6_u.__u6_addr32[1] == 0 && key->address.__in6_u.__u6_addr32[2] == 0) {
+		/* It's IPv4 */
+		printf("IPv4: 0x%X/%d", key->address.__in6_u.__u6_addr32[3], key->prefixlen);
+	} else {
+		/* It's an IPv6 address */
+		printf("IPv6: 0x%X/0x%X/0x%X/0x%X/%d",  key->address.__in6_u.__u6_addr32[0],
+				 key->address.__in6_u.__u6_addr32[1],  key->address.__in6_u.__u6_addr32[2],
+				  key->address.__in6_u.__u6_addr32[3], key->prefixlen);
+	}
+}
+
 int iphash_modify(int fd, char *ip_string, unsigned int action,
-		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd)
+		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd,
+		  __u32 prefix)
 {
 	//printf ("In iphash_modify %u\n",cpu_idx);
-	__u32 key;
+	struct ip_hash_key key;
 	int res;
 	unsigned int nr_cpus = bpf_num_possible_cpus();
 	struct ip_hash_info ip_info;
@@ -91,18 +144,12 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 	ip_info.cpu       = cpu_idx;
 	ip_info.tc_handle = tc_handle;
 
-	/* Convert IP-string into 32-bit network byte-order value */
-	res = inet_pton(AF_INET, ip_string, &key);
-	if (res <= 0) {
-		if (res == 0)
-			fprintf(stderr,
-				"ERR: IPv4 \"%s\" not in presentation format\n",
-				ip_string);
-		else
-			perror("inet_pton");
+	/* Convert IP-string into network byte-order value */
+	key = ip_string_to_key(ip_string, prefix);
+	if (key.prefixlen == 0) {
 		return EXIT_FAIL_IP;
 	}
-	printf ("key: 0x%X\n", key);
+	print_key_binary(&key);
 	if (action == ACTION_ADD) {
 		//res = bpf_map_update_elem(fd, &key, &ip_info, BPF_NOEXIST);
 		if (!map_txq_config_check_ip_info(txq_map_fd, &ip_info))
@@ -118,8 +165,8 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 
 	if (res != 0) { /* 0 == success */
 		fprintf(stderr,
-			"%s() IP:%s key:0x%X errno(%d/%s)",
-			__func__, ip_string, key, errno, strerror(errno));
+			"%s() IP:%s errno(%d/%s)",
+			__func__, ip_string, errno, strerror(errno));
 
 		if (errno == 17) {
 			fprintf(stderr, ": Already in Iphash\n");
@@ -130,8 +177,8 @@ int iphash_modify(int fd, char *ip_string, unsigned int action,
 	}
 	if (verbose)
 		fprintf(stderr,
-			"%s() IP:%s key:0x%X TC-handle:0x%X\n",
-			__func__, ip_string, key, tc_handle);
+			"%s() IP:%s TC-handle:0x%X\n",
+			__func__, ip_string, tc_handle);
 	return EXIT_OK;
 }
 

--- a/src/common_user.h
+++ b/src/common_user.h
@@ -43,7 +43,8 @@ extern const char *mapfile_cpu_map;
 #define ACTION_DEL	(1 << 1)
 
 int iphash_modify(int fd, char *ip_string, unsigned int action,
-		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd);
+		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd,
+		  __u32 prefix);
 
 bool locate_kern_object(char *execname, char *filename, size_t size);
 

--- a/src/common_user.h
+++ b/src/common_user.h
@@ -43,8 +43,7 @@ extern const char *mapfile_cpu_map;
 #define ACTION_DEL	(1 << 1)
 
 int iphash_modify(int fd, char *ip_string, unsigned int action,
-		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd,
-		  __u32 prefix);
+		  __u32 cpu_idx, __u32 tc_handle, int txq_map_fd);
 
 bool locate_kern_object(char *execname, char *filename, size_t size);
 

--- a/src/shared_maps.h
+++ b/src/shared_maps.h
@@ -7,11 +7,12 @@
 
 /* Pinned shared map: see  mapfile_ip_hash */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__uint(max_entries, IP_HASH_ENTRIES_MAX);
-	__type(key, __u32);
+	__type(key, struct ip_hash_key);
 	__type(value, struct ip_hash_info);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_ip_hash SEC(".maps");
 
 /* Map shared with XDP programs */

--- a/src/tc_classify_kern.c
+++ b/src/tc_classify_kern.c
@@ -195,7 +195,6 @@ void get_ipv6_addr(struct __sk_buff *skb, __u32 l3_offset, __u32 ifindex_type,
 
 	if (ip6h + 1 > data_end) {
 		//bpf_debug("Invalid IPv6 packet: L3off:%llu\n", l3_offset);
-		//*dst = nulladdr;
 		return;
 	}
 

--- a/src/xdp_iphash_to_cpu_cmdline.c
+++ b/src/xdp_iphash_to_cpu_cmdline.c
@@ -41,7 +41,6 @@ static const struct option long_options[] = {
         {"cpu",         required_argument,      NULL, 'c' },
         {"list",        no_argument,            NULL, 'l' },
         {"clear",       no_argument,            NULL, 'e' },
-	{"prefix",      required_argument,      NULL, 'p' },
         {0, 0, NULL,  0 }
 };
 
@@ -208,7 +207,6 @@ int main(int argc, char **argv) {
 	__u32 cpu = -1;
 	__u32 tc_handle = 0;
 	bool provided_classid = false;
-	__u32 prefix = 32;
 
 	while ((opt = getopt_long(argc, argv, "hac:t:i:le",
 				  long_options, &longindex)) != -1) {
@@ -221,9 +219,6 @@ int main(int argc, char **argv) {
 			break;
 		case 'c':
 			cpu = strtoul(optarg, NULL, 0);
-			break;
-		case 'p':
-			prefix = strtoul(optarg, NULL, 0);
 			break;
 		case 'i':
 			if (!optarg || strlen(optarg) >= STR_MAX) {
@@ -300,7 +295,7 @@ int main(int argc, char **argv) {
 			int txq_fd = open_bpf_map(mapfile_txq_config);
 			fd = open_bpf_map(mapfile_ip_hash);
 			res = iphash_modify(fd, ip_string, action, cpu,
-					    tc_handle, txq_fd, prefix);
+					    tc_handle, txq_fd);
 			close(fd);
 			close(txq_fd);
 		}

--- a/src/xdp_iphash_to_cpu_cmdline.c
+++ b/src/xdp_iphash_to_cpu_cmdline.c
@@ -86,7 +86,7 @@ static void iphash_print_ip(struct ip_hash_key ip, struct ip_hash_info *ip_info,
 		exit(EXIT_FAIL);
 	}
 
-	if (ip.address.__in6_u.__u6_addr32[0] == 0 && ip.address.__in6_u.__u6_addr32[1] == 0 && ip.address.__in6_u.__u6_addr32[2] == 0) {
+	if (ip.address.__in6_u.__u6_addr32[0] == 0xFFFFFFFF && ip.address.__in6_u.__u6_addr32[1] == 0xFFFFFFFF && ip.address.__in6_u.__u6_addr32[2] == 0xFFFFFFFF) {
 		// It's IPv4
 		if (!inet_ntop(AF_INET, &ip.address.__in6_u.__u6_addr32[3], ip_txt, sizeof(ip_txt))) {
 	                fprintf(stderr,

--- a/src/xdp_iphash_to_cpu_cmdline.c
+++ b/src/xdp_iphash_to_cpu_cmdline.c
@@ -42,7 +42,6 @@ static const struct option long_options[] = {
         {"list",        no_argument,            NULL, 'l' },
         {"clear",       no_argument,            NULL, 'e' },
 	{"prefix",      required_argument,      NULL, 'p' },
-	{"ip6",         no_argument,            NULL, '6' },
         {0, 0, NULL,  0 }
 };
 

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -110,10 +110,10 @@ static __always_inline struct ip_hash_info *get_ip_info(struct ip_hash_key *ip)
 	if (!ip_info) {
 		struct ip_hash_key null_addr;
 	        null_addr.prefixlen = 128;
-	        null_addr.address.in6_u.u6_addr32[0] = 0;
-	        null_addr.address.in6_u.u6_addr32[1] = 0;
-        	null_addr.address.in6_u.u6_addr32[2] = 0;
-	        null_addr.address.in6_u.u6_addr32[3] = 0;
+	        null_addr.address.in6_u.u6_addr32[0] = 0xFFFFFFFF;
+	        null_addr.address.in6_u.u6_addr32[1] = 0xFFFFFFFF;
+        	null_addr.address.in6_u.u6_addr32[2] = 0xFFFFFFFF;
+	        null_addr.address.in6_u.u6_addr32[3] = 0xFFFFFFFF;
 		/* On LAN side (XDP-ingress) some uncategorized traffic are
 		 * expected, e.g. services like DHCP are running and IPs
 		 * contacting captive portal (which are not yet configured)
@@ -145,10 +145,10 @@ __u32 parse_ip(struct xdp_md *ctx, __u32 l3_offset, __u32 ifindex, __u16 eth_pro
 	/* Setup the ip_hash_key lookup structure */
 	struct ip_hash_key lookup;
         lookup.prefixlen = 128;
-        lookup.address.in6_u.u6_addr32[0] = 0;
-        lookup.address.in6_u.u6_addr32[1] = 0;
-        lookup.address.in6_u.u6_addr32[2] = 0;
-        lookup.address.in6_u.u6_addr32[3] = 0;
+        lookup.address.in6_u.u6_addr32[0] = 0xFFFFFFFF;
+        lookup.address.in6_u.u6_addr32[1] = 0xFFFFFFFF;
+        lookup.address.in6_u.u6_addr32[2] = 0xFFFFFFFF;
+        lookup.address.in6_u.u6_addr32[3] = 0xFFFFFFFF;
 
 	/* WAN or LAN interface? */
 	direction_lookup = bpf_map_lookup_elem(&map_ifindex_type, &ifindex);


### PR DESCRIPTION
This PR does the following:

* Replaced the `map_ip_hash` structure with a `BPF_MAP_TYPE_LPM_TRIE`. The key is a new `ip_hash_key` structure, which contains a prefix length and 128-bit address storage.
* The `xdp_iphash_to_cpu_cmdline` has gained an extra flag, `--prefix`. You can add an address with a /24 using `xdp_iphash_to_cpu_cmdline --add --ip 100.64.1.3 --cpu 0 --classid 1:5 --prefix 24`.
* If you don't include `--prefix`, it defaults to `/32` for IPv4 and `/128` for IPv6 --- preserving compatibility with the existing setup (no changes required if you don't want to use these features).
* The command-line also now understands IPv6 addresses. So `xdp_iphash_to_cpu_cmdline --add --ip fe80::215:5dff:fe64:4d05 --cpu 0 --classid 1:5 --prefix 64` will setup a matcher for that IPv6 address and all of its children.
* The command-line `--list` function has changed to also show the prefix, e.g. `"100.64.1.3/24" : { "cpu" : 0, "tc_maj" : "1" , "tc_min" : "5" },` or `"fe80::215:5dff:fe64:4d05/64" : { "cpu" : 0, "tc_maj" : "1" , "tc_min" : "5" }`
* The `clear` command no-longer takes the really odd route of translating an address into a string, and then translating it right back again for each address to remove it; it just removes all items.
* Once read, all addresses are turned into 128-bit addresses. IPv4 is placed in the last 4 octets of the address, with the rest zeroed. The command-line adds 96 to IPv4 prefixes automatically, so you don't need to remember to turn /24 into /120 (which it will be internally).
* The classifier and `xdp_iphash_to_cpu` program use a Trie lookup, starting with 128-bits (trying for an exact match). In testing, it seems very fast. (I haven't formally benchmarked it)

My test environment consists of 3 VMs: one running the shaper (I'm using LibreQOS to generate the basic commands), and a VM on either side of a bridge in the shaper. `iperf` shows that it is shaping correctly both for known and unknown addresses, and is correctly placing prefixed addresses in the right group.

Also, if you add this you may want to reboot to get rid of the previous pinned map. I didn't add any code to remove/replace it.

FIXES https://github.com/xdp-project/xdp-cpumap-tc/issues/4

Replaces https://github.com/xdp-project/xdp-cpumap-tc/pull/13, with the addition of sign-offs and breaking it into separate commits.

References: https://github.com/rchac/LibreQoS/issues/57
Tagging: @tohojo @interduo @rchac 
