### PR TITLE
parse_eth: walk up to VLAN_MAX_DEPTH 802.1Q/1ad tags

### DIFF
--- a/src/tc_classify_kern.c
+++ b/src/tc_classify_kern.c
@@ -105,6 +105,11 @@ struct bpf_elf_map {
 #define TC_H_MAJOR(x) TC_H_MAJ(x)
 #define TC_H_MINOR(x) TC_H_MIN(x)
 
+/* Allow callers to redefine VLAN max depth at compile time */
+#ifndef VLAN_MAX_DEPTH
+#define VLAN_MAX_DEPTH 4
+#endif
+
 /* Parse Ethernet layer 2, extract network layer 3 offset and protocol
  *
  * Returns false on error and non-supported ether-type
@@ -115,6 +120,7 @@ bool parse_eth(struct ethhdr *eth, void *data_end,
 {
 	__u16 eth_type;
 	__u64 offset;
+	int i;
 
 	offset = sizeof(*eth);
 	if ((void *)eth + offset > data_end)
@@ -126,21 +132,14 @@ bool parse_eth(struct ethhdr *eth, void *data_end,
 	if (bpf_ntohs(eth_type) < ETH_P_802_3_MIN)
 		return false;
 
-	/* Handle VLAN tagged packet */
-	if (eth_type == bpf_htons(ETH_P_8021Q) ||
-	    eth_type == bpf_htons(ETH_P_8021AD)) {
+	/* Skip up to VLAN_MAX_DEPTH 802.1Q/802.1ad tags. */
+	#pragma unroll
+	for (i = 0; i < VLAN_MAX_DEPTH; i++) {
 		struct vlan_hdr *vlan_hdr;
 
-		vlan_hdr = (void *)eth + offset;
-		offset += sizeof(*vlan_hdr);
-		if ((void *)eth + offset > data_end)
-			return false;
-		eth_type = vlan_hdr->h_vlan_encapsulated_proto;
-	}
-	/* Handle double VLAN tagged packet */
-	if (eth_type == bpf_htons(ETH_P_8021Q) ||
-	    eth_type == bpf_htons(ETH_P_8021AD)) {
-		struct vlan_hdr *vlan_hdr;
+		if (eth_type != bpf_htons(ETH_P_8021Q) &&
+		    eth_type != bpf_htons(ETH_P_8021AD))
+			break;
 
 		vlan_hdr = (void *)eth + offset;
 		offset += sizeof(*vlan_hdr);

--- a/src/xdp_iphash_to_cpu_kern.c
+++ b/src/xdp_iphash_to_cpu_kern.c
@@ -53,6 +53,11 @@ struct {
 #define bpf_debug(fmt, ...) { } while (0)
 #endif
 
+/* Allow callers to redefine VLAN max depth at compile time */
+#ifndef VLAN_MAX_DEPTH
+#define VLAN_MAX_DEPTH 4
+#endif
+
 /* Parse Ethernet layer 2, extract network layer 3 offset and protocol
  *
  * Returns false on error and non-supported ether-type
@@ -63,6 +68,7 @@ bool parse_eth(struct ethhdr *eth, void *data_end,
 {
 	__u16 eth_type;
 	__u64 offset;
+	int i;
 
 	offset = sizeof(*eth);
 	if ((void *)eth + offset > data_end)
@@ -74,21 +80,14 @@ bool parse_eth(struct ethhdr *eth, void *data_end,
 	if (bpf_ntohs(eth_type) < ETH_P_802_3_MIN)
 		return false;
 
-	/* Handle VLAN tagged packet */
-	if (eth_type == bpf_htons(ETH_P_8021Q) ||
-	    eth_type == bpf_htons(ETH_P_8021AD)) {
+	/* Skip up to VLAN_MAX_DEPTH 802.1Q/802.1ad tags. */
+	#pragma unroll
+	for (i = 0; i < VLAN_MAX_DEPTH; i++) {
 		struct vlan_hdr *vlan_hdr;
 
-		vlan_hdr = (void *)eth + offset;
-		offset += sizeof(*vlan_hdr);
-		if ((void *)eth + offset > data_end)
-			return false;
-		eth_type = vlan_hdr->h_vlan_encapsulated_proto;
-	}
-	/* Handle double VLAN tagged packet */
-	if (eth_type == bpf_htons(ETH_P_8021Q) ||
-	    eth_type == bpf_htons(ETH_P_8021AD)) {
-		struct vlan_hdr *vlan_hdr;
+		if (eth_type != bpf_htons(ETH_P_8021Q) &&
+		    eth_type != bpf_htons(ETH_P_8021AD))
+			break;
 
 		vlan_hdr = (void *)eth + offset;
 		offset += sizeof(*vlan_hdr);


### PR DESCRIPTION
## Summary

Two `parse_eth()` instances in `src/xdp_iphash_to_cpu_kern.c` and
`src/tc_classify_kern.c` hand-unroll exactly two 802.1Q/1ad tag
unwraps. On frames with three or more VLAN tags, the function
returns with `eth_type` still set to `ETH_P_8021Q`. The caller
switch falls through to `default: return XDP_PASS` in
`xdp_iphash_to_cpu_kern.c`, and to "no match" in
`tc_classify_kern.c`. Per-IP CPU classification is bypassed for
those frames.

This PR replaces the hand-unrolled if-blocks with a bounded
`#pragma unroll` loop over `VLAN_MAX_DEPTH` (default 4), matching
the xdp-tools convention in `headers/xdp/parsing_helpers.h`.

Reported to @tohojo off-list; opening this PR per his suggestion.
Full technical detail is in the commit message.

## Sites touched

- `src/xdp_iphash_to_cpu_kern.c` — `parse_eth()` at L60-103;
  caller switch in `handle_eth_protocol()` at L215-234 is the path
  that hits `XDP_PASS` on the bypass.
- `src/tc_classify_kern.c` — `parse_eth()` at L110-160,
  byte-identical shape.

## Operational impact

For libreqos-shaped per-CPU dispatch deployments, triple-tagged
traffic bypasses the per-IP → CPU mapping and lands on whatever
CPU received the interrupt. The per-CPU HTB worker model is
defeated for that traffic, but the bypass is not visible at the TC
layer because kernel VLAN normalization in
`__netif_receive_skb()` makes `tc_classify_kern` see a different
tag count than the wire frame, and the per-customer HTB class is
re-established successfully. `tc -s class show` will not surface
the bug; XDP-side metrics (the `xdp_redirect_map` tracepoint, or
the cpumap target `run_cnt`) are required to detect it.

## Verification

- Compiles clean against the BPF target with `-Werror -Wall -O2`
  (default project flags).
- Reproduced bypass before fix:
  - **Synthetic netns + veth:** 3/3 frames bypass classification
    with three 802.1Q tags; 3/3 classified correctly with 0 or 1
    tag; same destination IP, same map.
  - **Native-mode XDP on ConnectX-6 Dx** with the actual
    `xdp_iphash_to_cpu_kern` binary, 200 packets per case,
    600/600 reached the bypass path.
- Post-fix: same reproducers no longer trigger the bypass at 1–4
  tags. 5+ tag frames continue to bypass, matching the documented
  xdp-tools `parse_ethhdr()` limit.

## Limitations

Frames with more than `VLAN_MAX_DEPTH` (default 4) tags still
bypass. This matches the xdp-tools `parse_ethhdr()` contract and
is the documented limit of the bounded walker. Real-world 5+ tag
traffic is not typical in libreqos-style deployments, but callers
can override `VLAN_MAX_DEPTH` at compile time if needed.
